### PR TITLE
add "make install" to copy ps2smap.irx to $(PS2SDK)/iop/irx/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,7 @@ clean:
 	$(MAKE) -C common clean
 	$(MAKE) -C smap clean
 	$(MAKE) -C smap-linux clean
+
+install:
+	mkdir -p $(PS2SDK)/iop/irx/
+	cp smap/ps2smap.irx $(PS2SDK)/iop/irx/


### PR DESCRIPTION
Some programs (at least kernelloader) expect ps2smap.irx in $(PS2SDK)/iop/irx/
Currently ps2eth's Makefile does not have an "install" section, so I've added one that copies ps2smap.irx to the expected path.