### PR TITLE
make install: avoid breaking existing software

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,7 @@ clean:
 	$(MAKE) -C smap-linux clean
 
 install:
+	mkdir -p $(PS2DEV)/ps2eth/smap
+	cp smap/ps2smap.irx $(PS2DEV)/ps2eth/smap/
 	mkdir -p $(PS2SDK)/iop/irx/
-	cp smap/ps2smap.irx $(PS2SDK)/iop/irx/
+	ln -s $(PS2DEV)/ps2eth/smap/ps2smap.irx $(PS2SDK)/iop/irx/


### PR DESCRIPTION
install ps2smap.irx to $PS2DEV/ps2eth/smap/ and link it to $PS2SDK/iop/irx/ to avoid breaking existing software